### PR TITLE
Sc0tts/add temporal average output variables

### DIFF
--- a/.bmi/cruAKtemp.cfg.tmpl
+++ b/.bmi/cruAKtemp.cfg.tmpl
@@ -7,8 +7,6 @@ run_description     | {run_description}      | string   | description of this co
 run_region          | {run_region}           | string   | general location of this domain
 run_resolution      | {run_resolution}       | string   | highres or lowres
 # Dates are converted to datetime.date objects
-dataset_start_date  | {dataset_start_date}   | string   | first day with valid data in dataset
-dataset_end_date    | {dataset_end_date}     | string   | last day with valid data in dataset
 reference_date      | {reference_date}       | string   | model time is relative to this date
 model_start_date    | {model_start_date}     | string   | first day with valid model data
 model_end_date      | {model_start_date}     | string   | last day with valid model data

--- a/.bmi/parameters.yaml
+++ b/.bmi/parameters.yaml
@@ -22,18 +22,6 @@ run_resolution:
     type: string
     default: lowres
     units: '-'
-dataset_start_date:
-  description: First day with valid data in dataset
-  value:
-    type: string
-    default: '1901-01-01'
-    units: '-'
-dataset_end_date:
-  description: Last day with valid data in dataset
-  value:
-    type: string
-    default: '2009-12-31'
-    units: '-'
 reference_date:
   description: Model time is relative to this date
   value:

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -47,14 +47,20 @@ class BmiCruAKtempMethod():
 
         self._output_var_names = (
             'atmosphere_bottom_air__temperature',
+            'atmosphere_bottom_air__temperature_months',
+            'atmosphere_bottom_air__temperature_year',
         )
 
         self._var_name_map = {
-            'atmosphere_bottom_air__temperature':        'T_air'
+            'atmosphere_bottom_air__temperature':        'T_air',
+            'atmosphere_bottom_air__temperature_months': 'T_air_prior_months',
+            'atmosphere_bottom_air__temperature_year':   'T_air_prior_year'
         }
 
         self._var_units_map = {
             'atmosphere_bottom_air__temperature':        'deg_C',
+            'atmosphere_bottom_air__temperature_months': 'deg_C',
+            'atmosphere_bottom_air__temperature_year':   'deg_C',
             'datetime__start':                           'days',
             'datetime__end':                             'days'}
 
@@ -89,6 +95,8 @@ class BmiCruAKtempMethod():
         # These are the links to the model's variables and
         # should be consistent with _var_name_map
             'atmosphere_bottom_air__temperature': self._model.T_air,
+            'atmosphere_bottom_air__temperature_months': self._model.T_air_prior_months,
+            'atmosphere_bottom_air__temperature_year': self._model.T_air_prior_year,
             'datetime__start':                    self._model.first_date,
             'datetime__end':                      self._model.last_date}
 
@@ -136,6 +144,10 @@ class BmiCruAKtempMethod():
         # Set the bmi temperature to the updated value in the model
         self._values['atmosphere_bottom_air__temperature'] = \
                 self._model.T_air
+        self._values['atmosphere_bottom_air__temperature_months'] = \
+                self._model.T_air_prior_months
+        self._values['atmosphere_bottom_air__temperature_year'] = \
+                self._model.T_air_prior_year
 
     def update_frac(self, time_fraction):
         """
@@ -148,6 +160,10 @@ class BmiCruAKtempMethod():
         self._model.update_temperature_values()
         self._values['atmosphere_bottom_air__temperature'] = \
                 self._model.T_air
+        self._values['atmosphere_bottom_air__temperature_months'] = \
+                self._model.T_air_prior_months
+        self._values['atmosphere_bottom_air__temperature_year'] = \
+                self._model.T_air_prior_year
 
     def update_until(self, stop_date):
         if stop_date < self._model.current_date:

--- a/cruAKtemp/examples/cruAKtemp_model.cfg
+++ b/cruAKtemp/examples/cruAKtemp_model.cfg
@@ -7,8 +7,6 @@ run_description     | north slope subset cruNCEP  | string   | description of th
 run_region          | Alaska                      | string   | general location of this domain
 run_resolution      | lowres                      | string   | highres or lowres
 # Dates are converted to datetime.date objects
-dataset_start_date  | 1901-01-01                  | string   | first day with valid data in dataset
-dataset_end_date    | 2009-12-31                  | string   | last day with valid data in dataset
 reference_date      | 1900-01-01                  | string   | model time is relative to this date
 model_start_date    | 1902-01-01                  | string   | first day with valid model data
 model_end_date      | 1910-12-31                  | string   | last day with valid model data

--- a/cruAKtemp/tests/test_bmi_cruAKtemp.py
+++ b/cruAKtemp/tests/test_bmi_cruAKtemp.py
@@ -49,7 +49,9 @@ def test_get_output_var_names():
     ct = cruAKtemp.bmi_cruAKtemp.BmiCruAKtempMethod()
     ct.initialize(cfg_file=default_config_filename)
     output_vars = ct.get_output_var_names()
-    output_list = ('atmosphere_bottom_air__temperature',)
+    output_list = ('atmosphere_bottom_air__temperature',
+                   'atmosphere_bottom_air__temperature_months',
+                   'atmosphere_bottom_air__temperature_year')
     # In the future, we may include the start and end datetimes as outputs
     #output_list = ('atmosphere_bottom_air__temperature', 'datetime__start',
     #               'datetime__end')

--- a/cruAKtemp/tests/test_bmi_cruAKtemp.py
+++ b/cruAKtemp/tests/test_bmi_cruAKtemp.py
@@ -30,7 +30,7 @@ def test_initialize_sets_times():
     # Can we call an initialize function?
     ct = cruAKtemp.bmi_cruAKtemp.BmiCruAKtempMethod()
     ct.initialize(cfg_file=default_config_filename)
-    assert_equal(ct._model.first_date, datetime.datetime(1902, 1, 1))
+    assert_equal(ct._model.first_date, datetime.date(1902, 1, 1))
 
 def test_att_map():
     ct = cruAKtemp.bmi_cruAKtemp.BmiCruAKtempMethod()

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -78,20 +78,6 @@ def test_get_timestep_from_date():
     #...and make the date 100 days later
     assert_equal(ct.first_date+this_timedelta, ct._current_date)
 
-def test_can_increment_by_fractions_of_days():
-    ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
-    ct.initialize_from_config_file()
-
-    # Adding 1.8 days twice should add 3.6 days to the date
-    # which truncates to 3.0 days to the timestep
-    this_timestep = 0
-    number_of_days = 1.8
-    this_timedelta = datetime.timedelta(days=number_of_days)
-    ct.increment_date(this_timedelta)
-    ct.increment_date(this_timedelta)
-    assert_equal(ct.first_date+2*this_timedelta, ct._current_date)
-    assert_equal(int(this_timestep+2*number_of_days), ct._current_timestep)
-
 def test_can_increment_to_end_of_run():
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
@@ -104,4 +90,3 @@ def test_can_increment_to_end_of_run():
     ct.update_temperature_values()
     ct.T_air.tofile("end_T_air.dat")
     # Note: nc time of 4000 corresponds to model date of Dec 15, 2010
-

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -26,6 +26,7 @@ import datetime
 def test_testing():
     # This should pass as long as this routine is getting called
     # and all the import statements above are working
+
     assert(True)
 
 # ---------------------------------------------------
@@ -78,13 +79,60 @@ def test_get_timestep_from_date():
     #...and make the date 100 days later
     assert_equal(ct.first_date+this_timedelta, ct._current_date)
 
+def test_time_index_yields_correct_values():
+    """ Check that we get the expected index into the netcdf file
+        for specified month and year """
+    ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
+    ct.initialize_from_config_file()
+
+    # Test that first month yields index zero
+    month = 1
+    year = 1901
+    idx = ct.get_time_index(month, year)
+    assert_equal(idx, 0)
+
+    # Test that a year later yields index 12
+    month = 1
+    year = 1902
+    idx = ct.get_time_index(month, year)
+    assert_equal(idx, 12)
+
+    # Test that a century and a year later yields index 1212
+    month = 1
+    year = 2002
+    idx = ct.get_time_index(month, year)
+    assert_equal(idx, 1212)
+
+def test_specific_netcdf_values():
+    """ Test that indexing yields specific values chosen from file
+        Values were hand-verified using panoply tables"""
+    ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
+    ct.initialize_from_config_file()
+
+    # Indexes here are based on the reduced-resolution grid, if used
+    # Note: Panoply has 1-based indexes, so must add 1 to these
+    #       to get Panoply equivalent
+    t_idx = 0
+    x_idx = 0
+    y_idx = 0
+    assert_almost_equal(ct._temperature[t_idx, y_idx, x_idx], -26.1, places=5)
+
+    t_idx = 20
+    x_idx = 0
+    y_idx = 0
+    assert_almost_equal(ct._temperature[t_idx, y_idx, x_idx], -0.3, places=5)
+
+    t_idx = 20
+    x_idx = 0
+    y_idx = 6
+    assert_almost_equal(ct._temperature[t_idx, y_idx, x_idx], -1.9, places=5)
+
+
 def test_can_increment_to_end_of_run():
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
 
-    # Adding 1.8 days twice should add 3.6 days to the date
-    # which truncates to 3.0 days to the timestep
-    number_of_days = ct._last_timestep
+    number_of_days = ct._last_timestep - ct._first_timestep
     this_timedelta = datetime.timedelta(days=number_of_days)
     ct.increment_date(this_timedelta)
     ct.update_temperature_values()

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -21,24 +21,13 @@ import datetime
 
 
 # ---------------------------------------------------
-# Tests that ensure we are reaching this testing file
-# ---------------------------------------------------
-def test_testing():
-    # This should pass as long as this routine is getting called
-    # and all the import statements above are working
-
-    assert(True)
-
-# ---------------------------------------------------
 # Tests that the frost_number module is importing
 # ---------------------------------------------------
 def test_can_initialize_cruAKtemp_class():
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod
 
-def test_for_cruAKtemp_utils():
-    ct = cu
-
 def test_write_gridfile():
+    """ Test that can write a gridfile to disk """
     # Create a temperature grid with default structure
     grid_desc = cruAKtemp.cruAKtemp_utils.write_gridfile('temperature')
 
@@ -55,14 +44,17 @@ def test_write_gridfile():
         pass
 
 def test_write_default_temperature_cfg_file():
+    """ test that util operation writes default cfg file """
     cruAKtemp.cruAKtemp_utils.generate_default_temperature_run_cfg_file(\
         SILENT=True)
 
 def test_initialize_opens_temperature_netcdf_file():
+    """ Test that temperature netcdf file is opened """
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
 
 def test_get_timestep_from_date():
+    """ Test get timestep from a date """
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
 
@@ -128,7 +120,25 @@ def test_specific_netcdf_values():
     assert_almost_equal(ct._temperature[t_idx, y_idx, x_idx], -1.9, places=5)
 
 
+def test_getting_monthly_annual_temp_values():
+    """ Test that prior_months and prior_year values are correct
+        Values were hand-verified using panoply tables"""
+    ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
+    ct.initialize_from_config_file()
+
+    actualvalues = [-28.700001, -24.799999, -16.600000, -2.700000,
+                     7.800000, 11.000000, 7.100000, -0.300000,
+                    -13.400000, -22.100000, -26.500000, -25.700001]
+    actualmean = -11.241668
+    vallist = []
+    for i in np.arange(0, 12):
+        vallist.append(ct.T_air_prior_months[i][0, 0])
+        assert_almost_equal(vallist[i], actualvalues[i], places=5)
+    assert_almost_equal(np.nanmean(vallist), actualmean, places=5)
+
+
 def test_can_increment_to_end_of_run():
+    """ Test that we can get values for last timestep """
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
 
@@ -138,3 +148,5 @@ def test_can_increment_to_end_of_run():
     ct.update_temperature_values()
     ct.T_air.tofile("end_T_air.dat")
     # Note: nc time of 4000 corresponds to model date of Dec 15, 2010
+
+

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -126,15 +126,18 @@ def test_getting_monthly_annual_temp_values():
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
 
+    # Test prior months values
     actualvalues = [-28.700001, -24.799999, -16.600000, -2.700000,
                      7.800000, 11.000000, 7.100000, -0.300000,
                     -13.400000, -22.100000, -26.500000, -25.700001]
-    actualmean = -11.241668
     vallist = []
     for i in np.arange(0, 12):
         vallist.append(ct.T_air_prior_months[i][0, 0])
         assert_almost_equal(vallist[i], actualvalues[i], places=5)
-    assert_almost_equal(np.nanmean(vallist), actualmean, places=5)
+
+    # Test prior year value
+    actualmean = -11.241668
+    assert_almost_equal(ct.T_air_prior_year[0, 0], actualmean, places=5)
 
 
 def test_can_increment_to_end_of_run():


### PR DESCRIPTION
Updated cruAKtemp and its BMI interface to keep track not only of the temperature values for its "current date", but also the prior year, and each of the previous 12 months.

Also some refactoring of the code that allows better decoupling of functionality.

And cleanup of several tests.

Oh...and valid dates for the data in the netcdf file are now derived from the attributes/values in the netcdf file itself rather than being specified in the config file.