### PR TITLE
Require the python-dateutil package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name='cruAKtemp',
       description='cruAKtemp',
       long_description=open('README.md').read(),
       packages=find_packages(),
-      install_requires=('numpy', 'nose', 'netcdf4', 'pyyaml'),
+      install_requires=('numpy', 'nose', 'netcdf4', 'pyyaml',
+                        'python-dateutil'),
       package_data={'': ['examples/*', 'data/*']}
 )


### PR DESCRIPTION
I think this is the same thing that @sc0tts found in https://github.com/permamodel/permamodel/commit/4e54eec4e368d9e9eade08731b793c24ffbd278d.
