### PR TITLE
Sc0tts/use year timestep

### DIFF
--- a/.bmi/cruAKtemp.cfg.tmpl
+++ b/.bmi/cruAKtemp.cfg.tmpl
@@ -6,10 +6,10 @@ filename            | {filename}             | string   | name of this file
 run_description     | {run_description}      | string   | description of this configuration
 run_region          | {run_region}           | string   | general location of this domain
 run_resolution      | {run_resolution}       | string   | highres or lowres
-# Dates are converted to datetime.date objects
-reference_date      | {reference_date}       | string   | model time is relative to this date
-model_start_date    | {model_start_date}     | string   | first day with valid model data
-model_end_date      | {model_start_date}     | string   | last day with valid model data
+# Model first, last, step [years]
+model_start_year    | {model_start_year}     | int      | first year of model run
+model_end_year      | {model_start_year}     | int      | last year of model run
+timestep            | {timestep}             | int      | model timestep [days]
 # Grid variables are processed separately after all config variables have been read in
 # need to create np.float array of grids
 grid_name           | {grid_name}            | string   | name of the model grid
@@ -18,7 +18,6 @@ grid_columns        | {grid_columns}         | int      | number of columns in m
 grid_rows           | {grid_rows}            | int      | number of columns in model grid
 #  with temperature as np.zeros((grid_columns, grid_rows), dtype=np.float)
 i_ul                | {i_ul}                 | int      | i-coord of upper left corner model domain
-j_ul                | {i_ul}                 | int      | j-coord of upper left corner model domain
+j_ul                | {j_ul}                 | int      | j-coord of upper left corner model domain
 # timestep is converted to datetime.timedelta(days=timestep)
-timestep            | {timestep}             | int      | model timestep [days]
 # Output

--- a/.bmi/cruAKtemp.cfg.tmpl
+++ b/.bmi/cruAKtemp.cfg.tmpl
@@ -7,9 +7,9 @@ run_description     | {run_description}      | string   | description of this co
 run_region          | {run_region}           | string   | general location of this domain
 run_resolution      | {run_resolution}       | string   | highres or lowres
 # Model first, last, step [years]
-model_start_year    | {model_start_year}     | int      | first year of model run
-model_end_year      | {model_start_year}     | int      | last year of model run
-timestep            | {timestep}             | int      | model timestep [days]
+model_start_year    | {model_start_year}     | long     | first year of model run
+model_end_year      | {model_end_year}       | long     | last year of model run
+timestep            | {timestep}             | int      | model timestep [yr]
 # Grid variables are processed separately after all config variables have been read in
 # need to create np.float array of grids
 grid_name           | {grid_name}            | string   | name of the model grid

--- a/.bmi/parameters.yaml
+++ b/.bmi/parameters.yaml
@@ -29,16 +29,22 @@ reference_date:
     default: '1900-01-01'
     units: '-'
 model_start_year:
-  description: First year with valid model data
+  description: Start year for retrieving data
   value:
     type: long
     default: 1902
+    range:
+      min: 1901
+      max: 2009
     units: yr
 model_end_year:
-  description: Last year with valid model data
+  description: End year for retrieving data
   value:
     type: long
     default: 1910
+    range:
+      min: 1901
+      max: 2009
     units: yr
 grid_name:
   description: Name of the model grid
@@ -57,21 +63,27 @@ grid_columns:
   value:
     type: int
     default: 40
+    range:
+      min: 1
+      max: 140
     units: '-'
 grid_rows:
   description: Number of rows in model grid
   value:
     type: int
     default: 20
+    range:
+      min: 1
+      max: 165
     units: '-'
 i_ul:
-  description: I-coordinate of upper left model domain
+  description: Column offset from upper left model domain
   value:
     type: int
     default: 50
     units: '-'
 j_ul:
-  description: J-coordinate of upper left model domain
+  description: Row offset from upper left model domain
   value:
     type: int
     default: 25

--- a/.bmi/parameters.yaml
+++ b/.bmi/parameters.yaml
@@ -28,18 +28,18 @@ reference_date:
     type: string
     default: '1900-01-01'
     units: '-'
-model_start_date:
-  description: First day with valid model data
+model_start_year:
+  description: First year with valid model data
   value:
-    type: string
-    default: '1902-01-01'
-    units: '-'
-model_end_date:
-  description: Last day with valid model data
+    type: long
+    default: 1902
+    units: yr
+model_end_year:
+  description: Last year with valid model data
   value:
-    type: string
-    default: '1910-12-31'
-    units: '-'
+    type: long
+    default: 1910
+    units: yr
 grid_name:
   description: Name of the model grid
   value:
@@ -81,4 +81,4 @@ timestep:
   value:
     type: int
     default: 1
-    units: 'days'
+    units: yr

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -255,6 +255,6 @@ if __name__ == "__main__":
     print("  (Starting at Panoply's (51, 26) which is (50, 25) in ")
     print("     0-based notation")
     print(crumeth._values['atmosphere_bottom_air__temperature'])
-    print("Current timestep (should be 2): %s" %
+    print("Current timestep (should be 1): %s" %
           str(crumeth.get_current_time()))
     crumeth.finalize()

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -8,20 +8,20 @@ monthly temperature values for Alaska
 For use with Permamodel components
 
 """
+from __future__ import print_function
 
-import numpy as np
 import os
+import numpy as np
 import cruAKtemp
+from tests import examples_directory
 
 """
 class FrostnumberMethod( frost_number.BmiFrostnumberMethod ):
     _thisname = 'this name'
 """
 
-class BmiCruAKtempMethod():
-
-
-
+class BmiCruAKtempMethod(object):
+    """ Provides BMI interface to cruAKtemp netcdf file """
     def __init__(self):
         self._model = None
         self._values = {}
@@ -41,7 +41,7 @@ class BmiCruAKtempMethod():
             'comp_name':          'cruAKtemp',
             'model_family':       'PermaModel',
             'cfg_extension':      '_cruAKtemp_model.cfg',
-            'time_units':         'days' }
+            'time_units':         'days'}
 
         self._input_var_names = ()
 
@@ -74,11 +74,11 @@ class BmiCruAKtempMethod():
 
         # Verify that all input and output variable names are mapped
         for varname in self._input_var_names:
-            assert(varname in self._var_name_map)
-            assert(varname in self._var_units_map)
+            assert varname in self._var_name_map
+            assert varname in self._var_units_map
         for varname in self._output_var_names:
-            assert(varname in self._var_name_map)
-            assert(varname in self._var_units_map)
+            assert varname in self._var_name_map
+            assert varname in self._var_units_map
 
         # Set a unique grid number for each grid
         gridnumber = 0
@@ -91,26 +91,24 @@ class BmiCruAKtempMethod():
             self._grid_type[gridnumber] = 'uniform_rectilinear'
             gridnumber += 1
 
-        self._values = _values = {
-        # These are the links to the model's variables and
-        # should be consistent with _var_name_map
+        self._values = {
+            # These are the links to the model's variables and
+            # should be consistent with _var_name_map
             'atmosphere_bottom_air__temperature': self._model.T_air,
             'atmosphere_bottom_air__temperature_months': self._model.T_air_prior_months,
             'atmosphere_bottom_air__temperature_year': self._model.T_air_prior_year,
             'datetime__start':                    self._model.first_date,
             'datetime__end':                      self._model.last_date}
 
-        self._model.status = 'initialized'
-
     def get_attribute(self, att_name):
 
         try:
-            return self._att_map[ att_name.lower() ]
-        except:
-            print '###################################################'
-            print ' ERROR: Could not find attribute: ' + att_name
-            print '###################################################'
-            print ' '
+            return self._att_map[att_name.lower()]
+        except KeyError:
+            print('###################################################')
+            print(' ERROR: Could not find attribute: %s' % str(att_name))
+            print('###################################################')
+            print(' ')
 
     def get_input_var_names(self):
         return self._input_var_names
@@ -123,10 +121,10 @@ class BmiCruAKtempMethod():
         return np.float64(0)
 
     def get_var_name(self, long_var_name):
-        return self._var_name_map[ long_var_name ]
+        return self._var_name_map[long_var_name]
 
     def get_var_units(self, long_var_name):
-        return self._var_units_map[ long_var_name ]
+        return self._var_units_map[long_var_name]
 
     def get_current_time(self):
         return self._model.get_current_timestep()
@@ -156,8 +154,10 @@ class BmiCruAKtempMethod():
         only be called if the integer value of the day changes
         """
         self._model.increment_date(
-            change_amount=time_fraction * self._model._timestep)
+            change_amount=time_fraction * self._model._timestep_duration)
         self._model.update_temperature_values()
+
+        self._model.update(frac=time_fraction)
         self._values['atmosphere_bottom_air__temperature'] = \
                 self._model.T_air
         self._values['atmosphere_bottom_air__temperature_months'] = \
@@ -166,38 +166,24 @@ class BmiCruAKtempMethod():
                 self._model.T_air_prior_year
 
     def update_until(self, stop_date):
-        if stop_date < self._model.current_date:
+        if stop_date < self._model._current_date:
             print("Warning: update_until date--%d--is less than current\
-                  date--%d" % (stop_date, self._model.current_date))
+                  date--%d" % (stop_date, self._model._current_date))
             print("  no update run")
             return
 
-        if stop_date > self._model._end_date:
+        if stop_date > self._model.last_date:
             print("Warning: update_until date--%d" % stop_date)
-            print("  was greater than end_date--%d." % self._model._end_date)
-            print("  Setting stop_date to _end_date")
-            stop_date = self._end_date
+            print("  was greater than end_date--%d." % self._model.last_date)
+            print("  Setting stop_date to last_date")
+            stop_date = self._model.last_date
 
         # Run update() one timestep at a time until stop_date
-        date = self._model.current_date
-        while date < stop_date:
+        while self._model._current_date < stop_date:
             self.update()
-            date = self._model.current_date
 
     def finalize(self):
-        SILENT = True
-
-        self._model.status = 'finalizing'
-
-        self._model.close_input_files()
-        self._model.write_output_to_file(SILENT=True)
-        self._model.close_output_files()
-
-        self._model.status = 'finalized'
-
-        if not SILENT:
-            self._model.print_final_report(\
-                    comp_name='Permamodel CruAKtemp component')
+        pass
 
     def get_grid_type(self, grid_number):
         return self._grid_type[grid_number]
@@ -206,7 +192,7 @@ class BmiCruAKtempMethod():
         # Model keeps track of timestep as a timedelta
         # Here, find the seconds and divide by seconds/day
         # to get the number of days
-        return self._model._timestep.total_seconds()/(24*60*60.0)
+        return self._model._timestep_duration
 
     def get_value_ref(self, var_name):
         return self._values[var_name]
@@ -228,7 +214,6 @@ class BmiCruAKtempMethod():
 
     def get_value(self, var_name):
         return np.asarray(self.get_value_ref(var_name))
-
 
     def get_var_type(self, var_name):
         return str(self.get_value_ref(var_name).dtype)
@@ -257,3 +242,19 @@ class BmiCruAKtempMethod():
 
     def get_grid_rank(self, var_id):
         return len(self.get_grid_shape(var_id))
+
+
+if __name__ == "__main__":
+    # Execute standalone test run
+    crumeth = BmiCruAKtempMethod()
+    crumeth.initialize(cfg_file=os.path.join(examples_directory,
+                                             'default_temperature.cfg'))
+    crumeth.update()
+    print("After one timestep, value of temperature array:")
+    print("  (This should be cruAKtemp for Dec 1903 (index=36 in Panoply)")
+    print("  (Starting at Panoply's (51, 26) which is (50, 25) in ")
+    print("     0-based notation")
+    print(crumeth._values['atmosphere_bottom_air__temperature'])
+    print("Current timestep (should be 2): %s" %
+          str(crumeth.get_current_time()))
+    crumeth.finalize()

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -244,6 +244,10 @@ class BmiCruAKtempMethod(object):
     def get_grid_spacing(self, grid_id):
         return np.array([10000.0, 10000.0], dtype='float32')
 
+    # Todo: Revise once we can work with georeferenced data in the CMF.
+    def get_grid_origin(self, grid_id):
+        return np.array([0.0, 0.0], dtype='float32')
+
     def get_grid_rank(self, var_id):
         return len(self.get_grid_shape(var_id))
 

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -240,6 +240,10 @@ class BmiCruAKtempMethod(object):
         else:
             return int(np.prod(grid_size))
 
+    # Todo: Revise once we can work with georeferenced data in the CMF.
+    def get_grid_spacing(self, grid_id):
+        return np.array([10000.0, 10000.0], dtype='float32')
+
     def get_grid_rank(self, var_id):
         return len(self.get_grid_shape(var_id))
 

--- a/cruAKtemp/cruAKtemp.py
+++ b/cruAKtemp/cruAKtemp.py
@@ -146,6 +146,9 @@ class CruAKtempMethod(object):
                         elif var_type == 'int':
                             # Convert integers to int
                             cfg_struct[var_name] = int(value)
+                        elif var_type == 'long':
+                            # Convert longs to int
+                            cfg_struct[var_name] = int(value)
                         else:
                             # Everything else is just passed as a string
                             cfg_struct[var_name] = value

--- a/cruAKtemp/cruAKtemp.py
+++ b/cruAKtemp/cruAKtemp.py
@@ -93,6 +93,26 @@ class CruAKtempMethod(object):
                   str(cfg['grid_shape']))
             raise
 
+    def verify_config_for_rectilinear_run(self, cfg):
+        # Need at least one grid
+        assert_greater_equal(len(cfg['grids']), 1)
+
+        # All grids need a valid data type
+        # name is a string, type is a type
+        for k, v in cfg['grids'].iteritems():
+            assert_true(isinstance(k, str))
+            assert_true(isinstance(type(v), type))
+
+        # Grid shape can be used to create a numpy array
+        assert_true(isinstance(cfg['grid_shape'], tuple))
+        try:
+            test_array = np.zeros(cfg['grid_shape'], dtype=np.uint8)
+            assert_true(test_array is not None)
+        except:
+            print("Grid shape can't be used for numpy array: %s" % \
+                  str(cfg['grid_shape']))
+            raise
+
     def get_config_from_oldstyle_file(self, cfg_filename):
         cfg_struct = {}
         grid_struct = {}

--- a/cruAKtemp/cruAKtemp.py
+++ b/cruAKtemp/cruAKtemp.py
@@ -5,41 +5,37 @@ cruAKtemp.py
 Reads average monthly temperature in Alaska from an upscaled version of
 CRU NCEP data for Alaska
 """
+from  __future__ import print_function
 
+import calendar
+import os
+import datetime as dt
+import yaml
+# Using netcdf3
+# from scipy.io.netcdf import NetCDFFile as Dataset
+# Using netcdf4
+from netCDF4 import Dataset
+from dateutil.relativedelta import relativedelta
 import numpy as np
 #from cruAKtemp.tests import examples_directory, data_directory
 from .tests import examples_directory, data_directory
-import cruAKtemp
-import bmi_cruAKtemp
-import os
-import calendar
-import yaml
-from nose.tools import (assert_is_instance, assert_greater_equal,
-                        assert_less_equal, assert_almost_equal,
-                        assert_greater, assert_in, assert_true,
-                        assert_equal)
-# Using netcdf3
-#from scipy.io.netcdf import NetCDFFile as Dataset
-# Using netcdf4
-from netCDF4 import Dataset
-import datetime as dt
-from dateutil.relativedelta import relativedelta
+from nose.tools import (assert_greater_equal, assert_less_equal,
+                        assert_true)
 
 def assert_between(value, minval, maxval):
     """Fail if value is not between minval and maxval"""
     assert_greater_equal(value, minval)
     assert_less_equal(value, maxval)
 
-class CruAKtempMethod():
+class CruAKtempMethod(object):
     def __init__(self):
         self._cru_temperature_nc_filename = None  # Name of input netcdf file
         self._cru_temperature_nc_filename_default = \
                 os.path.join(data_directory, "cruAKtemp.nc")
                                 # Default name of input netcdf file
-        self._cru_temperature_ncfile = None       # netCDF file handle
+        self._cru_temperature_ncfile = Dataset       # netCDF file handle
         self._cru_temperature = None # This will point to the nc file data
         self._current_date = None # Current num days since _start_date
-        self._status = None       # Current state of the model
         self._start_date = None   # Real date of start of model run
         self._end_date = None     # Date on which model run ends
         self._date_at_timestep0 = None  # this could be overwritten with set()
@@ -50,6 +46,29 @@ class CruAKtempMethod():
         self.T_air_prior_months = None  # Temperature grid each prior 12 months
         self.T_air_prior_year = None  # Temperature grid average prior 12 months
         self._time_units = "days"  # Timestep is in days
+
+        # The following are defined in config file
+        self.cfg_file = ""
+        self._nc_xdim = 0
+        self._nc_ydim = 0
+        self._nc_tdim = 0
+        self._nc_i0 = 0
+        self._nc_j0 = 0
+        self._nc_i1 = 0
+        self._nc_j1 = 0
+        self._nc_iskip = 0
+        self._nc_jskip = 0
+        self._first_valid_date = dt.date(2000, 1, 1)
+        self._last_valid_date = dt.date(1900, 1, 1)
+        self._timestep = dt.timedelta(days=1)
+        self._current_timestep = 0.0
+        self._first_timestep = 0.0
+        self._last_timestep = 0.0
+        self.first_date = dt.date(1900, 1, 1)
+        self.last_date = dt.date(1900, 1, 1)
+        self._grid_shape = (1, 1)
+        self.case_prefix = ""
+        self.site_prefix = ""
 
     def verify_config_for_uniform_rectilinear_run(self, cfg):
         # Need at least one grid
@@ -65,6 +84,7 @@ class CruAKtempMethod():
         assert_true(isinstance(cfg['grid_shape'], tuple))
         try:
             test_array = np.zeros(cfg['grid_shape'], dtype=np.uint8)
+            assert_true(test_array is not None)
         except:
             print("Grid shape can't be used for numpy array: %s" % \
                   str(cfg['grid_shape']))
@@ -86,7 +106,7 @@ class CruAKtempMethod():
                     COMMENT = (line[0] == '#')
 
                     words = line.split('|')
-                    if (len(words) ==4) and (not COMMENT):
+                    if (len(words) == 4) and (not COMMENT):
                         var_name = words[0].strip()
                         value = words[1].strip()
                         var_type = words[2].strip()
@@ -141,14 +161,14 @@ class CruAKtempMethod():
         # routine for each type of grid
         try:
             exec("self.verify_config_for_%s_run(cfg_struct)" %
-                cfg_struct['grid_type'])
+                 cfg_struct['grid_type'])
         except:
             raise
 
     def verify_temperature_netcdf_for_region_resolution(self, cfg_struct):
         try:
-            if 'lowres' == cfg_struct['run_resolution'] and \
-            'Alaska' == cfg_struct['run_region']:
+            if cfg_struct['run_resolution'] == 'lowres'  and \
+                cfg_struct['run_region'] == 'Alaska':
                 return os.path.join(data_directory,
                                     'cru_alaska_lowres_temperature.nc')
         except:
@@ -178,7 +198,7 @@ class CruAKtempMethod():
             i_nc = i
             if check_bounds:
                 assert_between(i_nc, 0, self._nc_xdim)
-            i = (i_nc - self.nc_i0)/self._nc_iskip
+            i = (i_nc - self._nc_i0)/self._nc_iskip
             if check_bounds:
                 assert_between(i, 0, self._grid_shape[0]-1)
             return i
@@ -201,7 +221,7 @@ class CruAKtempMethod():
             j_nc = j
             if check_bounds:
                 assert_between(j_nc, 0, self._nc_ydim)
-            j = (j_nc - self.nc_j0)/self._nc_jskip
+            j = (j_nc - self._nc_j0)/self._nc_jskip
             if check_bounds:
                 assert_between(j, 0, self._grid_shape[1]-1)
             return j
@@ -211,6 +231,8 @@ class CruAKtempMethod():
             nc_time_var = self._cru_temperature_ncfile.variables['time']
             nc_time_units = nc_time_var.getncattr('time_units').split()
             for part in nc_time_units:
+                # Most of these "part"s will fail,
+                # but the 'time_units' value will execute the try clause
                 try:
                     # If we get a datestring of YYYY-MM-DD, parse it
                     reference_time = \
@@ -232,20 +254,20 @@ class CruAKtempMethod():
                     self._last_valid_date = \
                             dt.date(last_date.year, last_date.month, day)
                     break
-                except:
+                except ValueError:
+                    # Expect most 'parts' of nc_time_units not to be date
                     pass
         except:
             raise
 
     def initialize_from_config_file(self, cfg_filename=None):
-        self.status     = 'initializing'
         cfg_struct = None
 
         # Set the cfg file if it exists, otherwise, a default
         if not cfg_filename:
-           # No config file specified, use a default
-           cfg_filename = os.path.join(examples_directory,
-                                   'default_temperature.cfg')
+            # No config file specified, use a default
+            cfg_filename = os.path.join(examples_directory,
+                                        'default_temperature.cfg')
 
         #cfg_struct = self.get_config_from_yaml_file(cfg_filename)
         cfg_struct = self.get_config_from_oldstyle_file(cfg_filename)
@@ -323,12 +345,16 @@ class CruAKtempMethod():
         # Read in the latitude and longitude arrays
         nc_latitude = self._cru_temperature_ncfile.variables['lat']
         self._latitude = \
-            np.asarray(nc_latitude[self._nc_j0:self._nc_j1:self._nc_jskip,
-            self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
+            np.asarray(
+                nc_latitude[
+                    self._nc_j0:self._nc_j1:self._nc_jskip,
+                    self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
         nc_longitude = self._cru_temperature_ncfile.variables['lon']
         self._longitude = \
-            np.asarray(nc_longitude[self._nc_j0:self._nc_j1:self._nc_jskip,
-            self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
+            np.asarray(
+                nc_longitude[
+                    self._nc_j0:self._nc_j1:self._nc_jskip,
+                    self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
 
         # If the variables that point to the netcdfile's variables
         # aren't independently closed, then a RuntimeWarning will be raised
@@ -342,9 +368,10 @@ class CruAKtempMethod():
         # the best way to read from files that are several GB in size
         nc_temperature = self._cru_temperature_ncfile.variables['temp']
         self._temperature = \
-            np.asarray(nc_temperature[:,
-            self._nc_j0:self._nc_j1:self._nc_jskip,
-            self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
+            np.asarray(
+                nc_temperature[
+                    :, self._nc_j0:self._nc_j1:self._nc_jskip,
+                    self._nc_i0:self._nc_i1:self._nc_iskip]).astype(np.float32)
         # Deduce the model xdim and ydim from the size of this array
         self._nc_tdim = nc_temperature.shape[0]
         self._nc_ydim = nc_temperature.shape[1]
@@ -366,7 +393,7 @@ class CruAKtempMethod():
         """Return the timestep from a date
         Note: assumes that the model's time values have been initialized
         """
-        this_timestep  = (this_date - self._date_at_timestep0).days / \
+        this_timestep = (this_date - self._date_at_timestep0).days / \
                     self._timestep.days
         return this_timestep
 
@@ -407,12 +434,12 @@ class CruAKtempMethod():
 
         testdate = dt.date(year, month, 1)
         # Check that month, year are in range
+        idx = self.get_time_index(month, year)
+        assert idx >= 0
         if (testdate < self._first_valid_date) or \
            (testdate > self._last_valid_date):
             return np.zeros_like(self._temperature[idx, :, :]).fill(np.nan)
 
-        idx = self.get_time_index(month, year)
-        assert idx >= 0
         return self._temperature[idx, :, :]
 
 
@@ -425,7 +452,6 @@ class CruAKtempMethod():
         """
         year = self._current_date.year
         month = self._current_date.month
-        day = self._current_date.month
         self.T_air = self.get_temperatures_month_year(month, year)
         self.T_air_prior_months = []
 
@@ -438,35 +464,35 @@ class CruAKtempMethod():
 
     def read_config_file(self):
         # Open CFG file to read data
-        cfg_unit = open( self.cfg_file, 'r' )
+        cfg_unit = open(self.cfg_file, 'r')
         last_var_name = ''
 
-        while (True):
-            line  = cfg_unit.readline()
-            if (line == ''):
+        while True:
+            line = cfg_unit.readline()
+            if line == '':
                 break                  # (reached end of file)
 
             # Comments are lines that start with '#'
             COMMENT = (line[0] == '#')
 
             # Columns are delimited by '|'
-            words   = line.split('|')
+            words = line.split('|')
 
             # Only process non-comment lines with exactly 4 words
             # Note: the 4th word describes the variable, and is ignored
-            if (len(words) == 4) and not(COMMENT):
+            if (len(words) == 4) and not COMMENT:
                 var_name = words[0].strip()
-                value    = words[1].strip()
+                value = words[1].strip()
                 var_type = words[2].strip()
 
-                READ_SCALAR   = False
+                READ_SCALAR = False
                 READ_FILENAME = False
 
                 # Does var_name end with an array subscript ?
                 p1 = var_name.rfind('[')
                 p2 = var_name.rfind(']')
                 if (p1 > 0) and (p2 > p1):
-                    var_base  = var_name[:p1]
+                    var_base = var_name[:p1]
                     subscript = var_name[p1:p2+1]
                     var_name_file_str = var_base + '_file' + subscript
                 else:
@@ -475,13 +501,14 @@ class CruAKtempMethod():
 
                 # if the immediately preceding line describes this variables's
                 # type, change the type of this variable
-                if (last_var_name.startswith(var_base + '_type')):
-                    exec( "type_choice = self." + last_var_name )
-                    if (type_choice.lower() == 'scalar'):
-                        exec( "self." + var_name_file_str + " = ''")
+                if last_var_name.startswith(var_base + '_type'):
+                    type_choice = "undefined"
+                    exec("type_choice = self." + last_var_name)
+                    if type_choice.lower() == 'scalar':
+                        exec("self." + var_name_file_str + " = ''")
                         READ_SCALAR = True
                     else:
-                        exec( "self." + var_name + " = 0.0")
+                        exec("self." + var_name + " = 0.0")
                         READ_FILENAME = True
 
                 #-----------------------------------
@@ -490,54 +517,56 @@ class CruAKtempMethod():
                 # Convert scalars to numpy scalars
                 #-----------------------------------
                 if (var_type in ['float64', 'np.float64']):
-                    value = np.float64( value )
-                    exec( "self." + var_name + " = value" )
+                    value = np.float64(value)
+                    exec("self." + var_name + " = value")
                 elif (var_type in ['float32', 'np.float32']):
-                    value = np.float32( value )
-                    exec( "self." + var_name + " = value" )
+                    value = np.float32(value)
+                    exec("self." + var_name + " = value")
                 elif (var_type in ['long', 'long int', 'np.int64']):
-                    value = np.int64( value )
-                    exec( "self." + var_name + " = value" )
+                    value = np.int64(value)
+                    exec("self." + var_name + " = value")
                 elif (var_type in ['int', 'np.int32']):
-                    value = np.int32( value )
-                    exec( "self." + var_name + " = value" )
+                    value = np.int32(value)
+                    exec("self." + var_name + " = value")
                 elif (var_type in ['short', 'short int', 'int16', 'np.int16']):
-                    value = np.int16( value )
-                    exec( "self." + var_name + " = value" )
-                elif (var_type == 'string'):
+                    value = np.int16(value)
+                    exec("self." + var_name + " = value")
+                elif var_type == 'string':
                     # Replace [case_prefix] or [site_prefix] in a string's value
                     # with the appropriate values
                     case_str = '[case_prefix]'
                     site_str = '[site_prefix]'
                     s = value
-                    if (s[:13] == case_str):
+                    if s[:13] == case_str:
                         value_str = (self.case_prefix + s[13:])
-                    elif (s[:13] == site_str):
+                    elif s[:13] == site_str:
                         value_str = (self.site_prefix  + s[13:])
                     else:
                         value_str = s
 
+                    assert value_str is not None
+
                     # If var_name starts with "SAVE_" and value is
                     # Yes or No, then convert to Python boolean.
-                    if (var_name[:5] == 'SAVE_'):
+                    if var_name[:5] == 'SAVE_':
                         VALUE_SET = True
                         if (s.lower() in ['yes', 'true']):
-                            exec( "self." + var_name + " = True" )
+                            exec("self." + var_name + " = True")
                         elif (s.lower() in ['no', 'false']):
-                            exec( "self." + var_name + " = False" )
+                            exec("self." + var_name + " = False")
                         else:
                             VALUE_SET = False
                     else:
                         VALUE_SET = False
 
                     # If string wasn't a SAVE_ variable, set it here
-                    if not(VALUE_SET):
-                        if (READ_FILENAME):
-                            exec( "self." + var_name_file_str + " = value_str" )
-                        elif (READ_SCALAR):
-                            exec( "self." + var_name + " = np.float64(value_str)")
+                    if not VALUE_SET:
+                        if READ_FILENAME:
+                            exec("self." + var_name_file_str + " = value_str")
+                        elif READ_SCALAR:
+                            exec("self." + var_name + " = np.float64(value_str)")
                         else:
-                            exec( "self." + var_name + " = value_str" )
+                            exec("self." + var_name + " = value_str")
                 else:
                     raise ValueError(\
                         "In read_config_file(), unsupported data type: %d" \

--- a/cruAKtemp/cruAKtemp.py
+++ b/cruAKtemp/cruAKtemp.py
@@ -17,7 +17,6 @@ import yaml
 from netCDF4 import Dataset
 from dateutil.relativedelta import relativedelta
 import numpy as np
-#from cruAKtemp.tests import examples_directory, data_directory
 from .tests import examples_directory, data_directory
 from nose.tools import (assert_greater_equal, assert_less_equal,
                         assert_true)
@@ -116,7 +115,6 @@ class CruAKtempMethod(object):
                             # date variables end with "_date"
                             cfg_struct[var_name] = \
                                 dt.datetime.strptime(value, "%Y-%m-%d").date()
-                                #dt.datetime.strptime(value, "%Y-%m-%d").date()
                         elif var_name[0:4] == 'grid':
                             # grid variables are processed after cfg file read
                             grid_struct[var_name] = value
@@ -175,7 +173,8 @@ class CruAKtempMethod(object):
             # Likely a KeyError because missing a region or resolution
             raise
 
-        raise ValueError("Combination of run_region '%s' and run_resolution '%s' not recognized" % \
+        raise ValueError(
+            "Combination of run_region '%s' and run_resolution '%s' not recognized" % \
                          (cfg_struct['run_region'],\
                           cfg_struct['run_resolution']))
 
@@ -269,7 +268,6 @@ class CruAKtempMethod(object):
             cfg_filename = os.path.join(examples_directory,
                                         'default_temperature.cfg')
 
-        #cfg_struct = self.get_config_from_yaml_file(cfg_filename)
         cfg_struct = self.get_config_from_oldstyle_file(cfg_filename)
 
         # Verify that the parameters are correct for the grid type
@@ -289,16 +287,12 @@ class CruAKtempMethod(object):
             # From config
             self._timestep = cfg_struct['timestep']
             self.first_date = cfg_struct['model_start_date']
+
             # This could be set externally, eg by WMT
             if self._date_at_timestep0 is None:
                 self._date_at_timestep0 = self.first_date
             self.last_date = cfg_struct['model_end_date']
-            ### CALL FUNCTION, DONT READ FROM STRUCT
-            #HERE
             self.get_first_last_dates_from_nc()
-            #self._first_valid_date = cfg_struct['dataset_start_date']
-            #self._last_valid_date = cfg_struct['dataset_end_date']
-            #HERE
 
             # Ensure that model dates are okay
             assert_between(self._date_at_timestep0,
@@ -470,7 +464,7 @@ class CruAKtempMethod(object):
         while True:
             line = cfg_unit.readline()
             if line == '':
-                break                  # (reached end of file)
+                break  # (reached end of file)
 
             # Comments are lines that start with '#'
             COMMENT = (line[0] == '#')

--- a/cruAKtemp/examples/default_temperature.cfg
+++ b/cruAKtemp/examples/default_temperature.cfg
@@ -6,22 +6,18 @@ filename            | default_temperature.cfg     | string   | name of this file
 run_description     | north slope subset cruNCEP  | string   | description of this configuration
 run_region          | Alaska                      | string   | general location of this domain
 run_resolution      | lowres                      | string   | highres or lowres
-# Dates are converted to datetime.date objects
-#dataset_start_date  | 1901-01-01                  | string   | first day with valid data in dataset
-#dataset_end_date    | 2009-12-31                  | string   | last day with valid data in dataset
-#reference_date      | 1900-01-01                  | string   | model time is relative to this date
+# Model start, end, step
 model_start_year    | 1902                        | int      | first year of model run
 model_end_year      | 1910                        | int      | last year of model run
+timestep            | 1                           | int      | model timestep [years]
 # Grid variables are processed separately after all config variables have been read in
 # need to create np.float array of grids
 grid_name           | temperature                 | string   | name of the model grid
-grid_type           | uniform_rectilinear         | string   | form of the model grid
+grid_type           | rectilinear                 | string   | form of the model grid
 grid_columns        | 40                          | int      | number of columns in model grid
 grid_rows           | 20                          | int      | number of rows in model grid
 #  with temperature as np.zeros((grid_columns, grid_rows), dtype=np.float)
 i_ul                | 50                          | int      | i-coord of upper left corner model domain
 j_ul                | 25                          | int      | j-coord of upper left corner model domain
-# timestep is converted to datetime.timedelta(days=timestep)
-timestep            | 1                           | int      | model timestep [years]
 #
 # Output

--- a/cruAKtemp/examples/default_temperature.cfg
+++ b/cruAKtemp/examples/default_temperature.cfg
@@ -7,11 +7,11 @@ run_description     | north slope subset cruNCEP  | string   | description of th
 run_region          | Alaska                      | string   | general location of this domain
 run_resolution      | lowres                      | string   | highres or lowres
 # Dates are converted to datetime.date objects
-dataset_start_date  | 1901-01-01                  | string   | first day with valid data in dataset
-dataset_end_date    | 2009-12-31                  | string   | last day with valid data in dataset
-reference_date      | 1900-01-01                  | string   | model time is relative to this date
-model_start_date    | 1902-01-01                  | string   | first day with valid model data
-model_end_date      | 1910-12-31                  | string   | last day with valid model data
+#dataset_start_date  | 1901-01-01                  | string   | first day with valid data in dataset
+#dataset_end_date    | 2009-12-31                  | string   | last day with valid data in dataset
+#reference_date      | 1900-01-01                  | string   | model time is relative to this date
+model_start_year    | 1902                        | int      | first year of model run
+model_end_year      | 1910                        | int      | last year of model run
 # Grid variables are processed separately after all config variables have been read in
 # need to create np.float array of grids
 grid_name           | temperature                 | string   | name of the model grid
@@ -22,6 +22,6 @@ grid_rows           | 20                          | int      | number of rows in
 i_ul                | 50                          | int      | i-coord of upper left corner model domain
 j_ul                | 25                          | int      | j-coord of upper left corner model domain
 # timestep is converted to datetime.timedelta(days=timestep)
-timestep            | 1                           | int      | model timestep [days]
+timestep            | 1                           | int      | model timestep [years]
 #
 # Output

--- a/cruAKtemp/tests/test_bmi_cruAKtemp.py
+++ b/cruAKtemp/tests/test_bmi_cruAKtemp.py
@@ -30,7 +30,6 @@ def test_initialize_sets_times():
     # Can we call an initialize function?
     ct = cruAKtemp.bmi_cruAKtemp.BmiCruAKtempMethod()
     ct.initialize(cfg_file=default_config_filename)
-    #assert_equal(ct._model.first_date, datetime.date(1902, 1, 1))
     assert_equal(ct._model.first_date, datetime.date(1902, 12, 15))
 
 def test_att_map():

--- a/cruAKtemp/tests/test_bmi_cruAKtemp.py
+++ b/cruAKtemp/tests/test_bmi_cruAKtemp.py
@@ -30,7 +30,8 @@ def test_initialize_sets_times():
     # Can we call an initialize function?
     ct = cruAKtemp.bmi_cruAKtemp.BmiCruAKtempMethod()
     ct.initialize(cfg_file=default_config_filename)
-    assert_equal(ct._model.first_date, datetime.date(1902, 1, 1))
+    #assert_equal(ct._model.first_date, datetime.date(1902, 1, 1))
+    assert_equal(ct._model.first_date, datetime.date(1902, 12, 15))
 
 def test_att_map():
     ct = cruAKtemp.bmi_cruAKtemp.BmiCruAKtempMethod()

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -3,13 +3,7 @@ test_cruAKtemp.py
   tests of the cruAKtemp component of permamodel
 """
 
-#from permamodel.components import frost_number
-#from permamodel.components import bmi_frost_number
-#from cruAKtemp import *
-#import cruAKtemp.cruAKtemp as cruAKtemp
 import cruAKtemp
-import cruAKtemp.cruAKtemp_utils as cu
-#from .cruAKtemp_utils import *
 import os
 import numpy as np
 from ..tests import data_directory, examples_directory
@@ -18,6 +12,7 @@ from nose.tools import (assert_is_instance, assert_greater_equal,
                         assert_greater, assert_in, assert_true,
                         assert_equal)
 import datetime
+from dateutil.relativedelta import relativedelta
 
 
 # ---------------------------------------------------
@@ -62,13 +57,13 @@ def test_get_timestep_from_date():
     this_timestep = 0
     assert_equal(this_timestep, ct._current_timestep)
 
-    # Adding 100 days should make the current timestep 100
-    number_of_days = 100
-    this_timedelta = datetime.timedelta(days=number_of_days)
-    ct.increment_date(this_timedelta)
-    assert_equal(this_timestep+number_of_days, ct._current_timestep)
+    # Adding 10 years should make the current timestep 10
+    number_of_years = 10
+    ct.increment_date(number_of_years)
+    assert_equal(10, ct._current_timestep)
 
-    #...and make the date 100 days later
+    #...and make the date 10 days later
+    this_timedelta = relativedelta(years=number_of_years)
     assert_equal(ct.first_date+this_timedelta, ct._current_date)
 
 def test_time_index_yields_correct_values():
@@ -127,27 +122,35 @@ def test_getting_monthly_annual_temp_values():
     ct.initialize_from_config_file()
 
     # Test prior months values
-    actualvalues = [-28.700001, -24.799999, -16.600000, -2.700000,
-                     7.800000, 11.000000, 7.100000, -0.300000,
-                    -13.400000, -22.100000, -26.500000, -25.700001]
+    # These are values starting from 2/1901
+    #actualvalues = [-28.700001, -24.799999, -16.600000, -2.700000,
+    #                 7.800000, 11.000000, 7.100000, -0.300000,
+    #                -13.400000, -22.100000, -26.500000, -25.700001]
+    #actualmean = -11.241668
+
+    # These values start with 1/1902
+    actualvalues = [-25.7, -27.0, -26.6, -16.9, -2.8, 8.1,
+                    11.4, 7.3, -0.3, -13.6, -22.1, -28.9]
+    actualmean = -11.425
+
     vallist = []
+
     for i in np.arange(0, 12):
         vallist.append(ct.T_air_prior_months[i][0, 0])
+
+    for i in np.arange(0, 12):
         assert_almost_equal(vallist[i], actualvalues[i], places=5)
 
     # Test prior year value
-    actualmean = -11.241668
     assert_almost_equal(ct.T_air_prior_year[0, 0], actualmean, places=5)
-
 
 def test_can_increment_to_end_of_run():
     """ Test that we can get values for last timestep """
     ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
     ct.initialize_from_config_file()
 
-    number_of_days = ct._last_timestep - ct._first_timestep
-    this_timedelta = datetime.timedelta(days=number_of_days)
-    ct.increment_date(this_timedelta)
+    number_of_years = ct._last_timestep - ct._first_timestep
+    ct.increment_date(number_of_years)
     ct.update_temperature_values()
     ct.T_air.tofile("end_T_air.dat")
     # Note: nc time of 4000 corresponds to model date of Dec 15, 2010

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -152,4 +152,9 @@ def test_can_increment_to_end_of_run():
     ct.T_air.tofile("end_T_air.dat")
     # Note: nc time of 4000 corresponds to model date of Dec 15, 2010
 
-
+def test_first_and_last_valid_dates():
+    """ Test that first and last valid dates are read from netcdf file """
+    ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
+    ct.initialize_from_config_file()
+    assert_equal(datetime.date(1901,1,1), ct._first_valid_date)
+    assert_equal(datetime.date(2009,12,31), ct._last_valid_date)


### PR DESCRIPTION
This code changes cruAKtemp so that it uses years for the timestep unit.  Internally, the code still uses dates, though the nominal date for each 'year' is Dec 15th.  This lets the 12 calendar months be Jan-Dec of that year, and lets the 12-month average be that year's calendar average value.

Also, a lot of code cleanup motivated by pylint warnings/errors.