### PR TITLE
pass jan and jul fields instead of list of all 12 monthly fields

### DIFF
--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -206,7 +206,8 @@ class BmiCruAKtempMethod(object):
         return self._values[var_name]
 
     def set_value(self, var_name, new_var_values):
-        self._values[var_name] = new_var_values
+        val = self.get_value_ref(var_name)
+        val[:] = new_var_values
 
     def set_value_at_indices(self, var_name, new_var_values, indices):
         self.get_value_ref(var_name).flat[indices] = new_var_values
@@ -221,7 +222,7 @@ class BmiCruAKtempMethod(object):
         return np.asarray(self.get_value_ref(var_name)).nbytes
 
     def get_value(self, var_name):
-        return np.asarray(self.get_value_ref(var_name))
+        return self.get_value_ref(var_name).copy()
 
     def get_var_type(self, var_name):
         return str(self.get_value_ref(var_name).dtype)

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -47,19 +47,22 @@ class BmiCruAKtempMethod(object):
 
         self._output_var_names = (
             'atmosphere_bottom_air__temperature',
-            'atmosphere_bottom_air__temperature_months',
+            'atmosphere_bottom_air__temperature_mean_jan',
+            'atmosphere_bottom_air__temperature_mean_jul',
             'atmosphere_bottom_air__temperature_year',
         )
 
         self._var_name_map = {
             'atmosphere_bottom_air__temperature':        'T_air',
-            'atmosphere_bottom_air__temperature_months': 'T_air_prior_months',
+            'atmosphere_bottom_air__temperature_mean_jan': 'T_air_prior_jan',
+            'atmosphere_bottom_air__temperature_mean_jul': 'T_air_prior_jul',
             'atmosphere_bottom_air__temperature_year':   'T_air_prior_year'
         }
 
         self._var_units_map = {
             'atmosphere_bottom_air__temperature':        'deg_C',
-            'atmosphere_bottom_air__temperature_months': 'deg_C',
+            'atmosphere_bottom_air__temperature_mean_jan': 'deg_C',
+            'atmosphere_bottom_air__temperature_mean_jul': 'deg_C',
             'atmosphere_bottom_air__temperature_year':   'deg_C',
             'datetime__start':                           'days',
             'datetime__end':                             'days'}
@@ -95,7 +98,8 @@ class BmiCruAKtempMethod(object):
             # These are the links to the model's variables and
             # should be consistent with _var_name_map
             'atmosphere_bottom_air__temperature': self._model.T_air,
-            'atmosphere_bottom_air__temperature_months': self._model.T_air_prior_months,
+            'atmosphere_bottom_air__temperature_mean_jan': self._model.T_air_prior_jan,
+            'atmosphere_bottom_air__temperature_mean_jul': self._model.T_air_prior_jul,
             'atmosphere_bottom_air__temperature_year': self._model.T_air_prior_year,
             'datetime__start':                    self._model.first_date,
             'datetime__end':                      self._model.last_date}
@@ -142,8 +146,10 @@ class BmiCruAKtempMethod(object):
         # Set the bmi temperature to the updated value in the model
         self._values['atmosphere_bottom_air__temperature'] = \
                 self._model.T_air
-        self._values['atmosphere_bottom_air__temperature_months'] = \
-                self._model.T_air_prior_months
+        self._values['atmosphere_bottom_air__temperature_mean_jan'] = \
+                self._model.T_air_prior_jan
+        self._values['atmosphere_bottom_air__temperature_mean_jan'] = \
+                self._model.T_air_prior_jul
         self._values['atmosphere_bottom_air__temperature_year'] = \
                 self._model.T_air_prior_year
 
@@ -160,8 +166,10 @@ class BmiCruAKtempMethod(object):
         self._model.update(frac=time_fraction)
         self._values['atmosphere_bottom_air__temperature'] = \
                 self._model.T_air
-        self._values['atmosphere_bottom_air__temperature_months'] = \
-                self._model.T_air_prior_months
+        self._values['atmosphere_bottom_air__temperature_mean_jan'] = \
+                self._model.T_air_prior_jan
+        self._values['atmosphere_bottom_air__temperature_mean_jul'] = \
+                self._model.T_air_prior_jul
         self._values['atmosphere_bottom_air__temperature_year'] = \
                 self._model.T_air_prior_year
 

--- a/cruAKtemp/bmi_cruAKtemp.py
+++ b/cruAKtemp/bmi_cruAKtemp.py
@@ -148,7 +148,7 @@ class BmiCruAKtempMethod(object):
                 self._model.T_air
         self._values['atmosphere_bottom_air__temperature_mean_jan'] = \
                 self._model.T_air_prior_jan
-        self._values['atmosphere_bottom_air__temperature_mean_jan'] = \
+        self._values['atmosphere_bottom_air__temperature_mean_jul'] = \
                 self._model.T_air_prior_jul
         self._values['atmosphere_bottom_air__temperature_year'] = \
                 self._model.T_air_prior_year

--- a/cruAKtemp/cruAKtemp.py
+++ b/cruAKtemp/cruAKtemp.py
@@ -41,6 +41,8 @@ class CruAKtempMethod(object):
         self._temperature = None # Will point to this model's temperature grid
         self.T_air = None        # Temperature grid
         self.T_air_prior_months = None  # Temperature grid each prior 12 months
+        self.T_air_prior_jan = None  # Temperature grid prior January
+        self.T_air_prior_jul = None  # Temperature grid prior July
         self.T_air_prior_year = None  # Temperature grid average prior 12 months
         self._time_units = "years"  # Timestep is in years
         self._timestep_duration = 0
@@ -500,6 +502,8 @@ class CruAKtempMethod(object):
             self.T_air_prior_months.append(
                 self.get_temperatures_month_year(
                     thisdate.month, thisdate.year))
+        self.T_air_prior_jan = self.T_air_prior_months[0]
+        self.T_air_prior_jul = self.T_air_prior_months[6]
         self.T_air_prior_year = np.average(self.T_air_prior_months, axis=0)
 
     def read_config_file(self):

--- a/cruAKtemp/tests/test_bmi_cruAKtemp.py
+++ b/cruAKtemp/tests/test_bmi_cruAKtemp.py
@@ -50,7 +50,8 @@ def test_get_output_var_names():
     ct.initialize(cfg_file=default_config_filename)
     output_vars = ct.get_output_var_names()
     output_list = ('atmosphere_bottom_air__temperature',
-                   'atmosphere_bottom_air__temperature_months',
+                   'atmosphere_bottom_air__temperature_mean_jan',
+                   'atmosphere_bottom_air__temperature_mean_jul',
                    'atmosphere_bottom_air__temperature_year')
     # In the future, we may include the start and end datetimes as outputs
     #output_list = ('atmosphere_bottom_air__temperature', 'datetime__start',
@@ -62,4 +63,7 @@ def test_get_var_name():
     ct.initialize(cfg_file=default_config_filename)
     this_var_name = ct.get_var_name('atmosphere_bottom_air__temperature')
     assert_equal(this_var_name, 'T_air')
+    this_var_name = \
+        ct.get_var_name('atmosphere_bottom_air__temperature_mean_jul')
+    assert_equal(this_var_name, 'T_air_prior_jul')
 

--- a/cruAKtemp/tests/test_cruAKtemp.py
+++ b/cruAKtemp/tests/test_cruAKtemp.py
@@ -161,3 +161,13 @@ def test_first_and_last_valid_dates():
     ct.initialize_from_config_file()
     assert_equal(datetime.date(1901,1,1), ct._first_valid_date)
     assert_equal(datetime.date(2009,12,31), ct._last_valid_date)
+
+def test_jan_jul_arrays():
+    """ test that cruAKtemp provides Jan and Jul values as individual arrays """
+    ct = cruAKtemp.cruAKtemp.CruAKtempMethod()
+    ct.initialize_from_config_file()
+    expected_jan_val = -25.7
+    expected_jul_val = 11.4
+
+    assert_almost_equal(ct.T_air_prior_jan[0, 0], expected_jan_val, places=5)
+    assert_almost_equal(ct.T_air_prior_jul[0, 0], expected_jul_val, places=5)


### PR DESCRIPTION
A structure of 12 2D fields is too complicated to pass in PyMT.  For FrostnumberGeo now, we only need the January and July fields, so provide each of those as separate output variables.